### PR TITLE
Added Radio Mast Reference Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ because I don't listen to them.
   - [YouAreListening.to](http://youarelistening.to) ← Ambient played over Police Scanners
   - [CampusFM](https://www.campus-fm.com) ← Aggregate of College Radio Stations
   - [Radio Reference](https://www.radioreference.com) ← Frequency database and information source
+  - [Radio Mast Reference Audio Streams](https://www.radiomast.io/reference-streams) ← Sample audio streams with various codecs and formats, including HLS
 


### PR DESCRIPTION
Hey Mike, we recently published a list of sample streams that are all playing the same content over at Radio Mast. While developing various features for [RSAS](https://www.rocketbroadcaster.com/streaming-audio-server) and Radio Mast, we found it really handy to have these available for QA testing and comparing codecs. We've been sharing this list with developers and hardware manufacturers for QA testing.

These streams are especially handy because there's some rare combinations that are hard to find stable links for, including:

- an Ogg FLAC stream (with a known bit depth), and including in-stream ICY metadata
- HLS streams for MP3 and AAC
- HE-AAC v1 and v2, side-by-side, including low bit-rate versions for comparison

Our site also has links to M3U playlists containing all the streams too, which is sometimes useful for quickly comparing the streams side-by-side. I didn't want to copy one of those playlists into the repo here since we're already keeping it up-to-date upstream, so there's no point in just duplicating it here and risking it becoming outdate.

Anyways, just wanted to share this because I hope it's a useful contribution to your list.

Thanks for your consideration!